### PR TITLE
Feat: Allow close code and close reason to be exposed

### DIFF
--- a/discord_gateway/conn.py
+++ b/discord_gateway/conn.py
@@ -360,7 +360,11 @@ class DiscordConnection:
                 else:
                     # It should be ConnectionState.REMOTE_CLOSING and we need
                     # to reply to the closure
-                    raise CloseDiscordConnection(self._proto.send(event.response()))
+                    raise CloseDiscordConnection(
+                        self._proto.send(event.response()),
+                        code=event.code,
+                        reason=event.reason,
+                    )
 
             elif isinstance(event, TextMessage):
                 # Compressed message will only show up as ByteMessage events,

--- a/discord_gateway/errors.py
+++ b/discord_gateway/errors.py
@@ -10,10 +10,23 @@ class CloseDiscordConnection(Exception):
 
     The `data` attribute contains any potentially last bytes to send before
     closing the TCP socket - or None indicating that nothing should be sent.
+
+    The `code` attribute is the close code and the `reason` attribute optionally
+    contains the reason of the closure.
     """
 
-    def __init__(self, data: Optional[bytes]) -> None:
-        super().__init__()
+    def __init__(
+        self,
+        data: Optional[bytes],
+        code: Optional[int] = None,
+        reason: Optional[str] = None
+    ) -> None:
+        super().__init__(
+            f"{code if code is not None else ''}{' - '+reason if reason is not None else ''}"
+        )
+
+        self.code = code
+        self.reason = reason
 
         self.data = data
 


### PR DESCRIPTION
The following change exposes the close code and the reason of the closure for users when the `CloseDiscordConnection` exception is raised.